### PR TITLE
Fixed Dockerfile shell command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,17 +80,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '37 0 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,13 +35,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
+      - name: Install Cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        uses: sigstore/cosign-installer@v3.5.0
         with:
-          cosign-release: 'v1.11.0'
+          cosign-release: 'v2.2.4'
+      
+      - name: Check Cosign Install!
+        run: cosign version
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '37 0 * * *'
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.11.0'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openfortivpn-haproxy
+# openfortivpn-socat
 This docker image proxies tcp ports across a Fortinet VPN to remote host using
 [openfortivpn](https://github.com/adrienverge/openfortivpn)
 and [socat](http://www.dest-unreach.org/socat/).

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # openfortivpn-haproxy
 This docker image proxies tcp ports across a Fortinet VPN to remote host using
 [openfortivpn](https://github.com/adrienverge/openfortivpn)
-and ~~[haproxy](https://www.haproxy.org/)~~ 
-[socat](http://www.dest-unreach.org/socat/).
+and [socat](http://www.dest-unreach.org/socat/).
+
+Originally created by: https://github.com/jeffre/openfortivpn-socat
 
 
 # Create docker image
 1. Clone this repository
 
-        git clone https://github.com/jeffre/openfortivpn-haproxy
+        git clone https://github.com/innobraingmbh/openfortivpn-socat
 
 2. Build the image
 
-        docker build ./openfortivpn-haproxy \
-            -t "jeffre/openfortivpn-haproxy:latest"
+        docker build ./openfortivpn-socat \
+            -t "innobraingmbh/openfortivpn-socat:latest"
 
     Alternatively, you may specify the openfortivpn version using `--build-arg`
 
-        docker build ./openfortivpn-haproxy \
-            -t "jeffre/openfortivpn-haproxy:v1.17.1" \
+        docker build ./openfortivpn-socat \
+            -t "innobraingmbh/openfortivpn-socat:v1.17.1" \
             --build-arg OPENFORTIVPN_VERSION=v1.17.1
 
 
@@ -118,4 +119,24 @@ docker run --rm -it \
     -e PORT_FORWARD="3389:10.0.0.1:3389" \
     jeffre/openfortivpn-haproxy:latest \
     fortinet.example.com:8443
+```
+
+# Example docker-compose
+To use this, add the VPN as a service. Set all needed env vars, start once. Then add the thrown cert sha into the `TRUSTED_CERT` env var.
+```
+  vpn:
+    build:
+      context: .
+      dockerfile: vpn.dockerfile
+    image: innobraingmbh/docker-forticlient:latest
+    environment:
+      - PORT_FORWARD
+    command: ${VPNADDR} --username=${VPNUSER} --password=${VPNPASS} --trusted-cert=${TRUSTED_CERT}
+    labels:
+      - container-type=vpnclient
+      - vpn-type=openfortivpn
+    privileged: true
+    networks:
+      - default
+    restart: unless-stopped
 ```

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ To use this, add the VPN as a service. Set all needed env vars, start once. Then
   vpn:
     build:
       context: .
-      dockerfile: vpn.dockerfile
-    image: innobraingmbh/docker-forticlient:latest
+      dockerfile: Dockerfile
+    image: innobraingmbh/openfortivpn-socat:latest
     environment:
       - PORT_FORWARD
     command: ${VPNADDR} --username=${VPNUSER} --password=${VPNPASS} --trusted-cert=${TRUSTED_CERT}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Openfortivpn configuration can be provided as command-line arguments to this
 image, as a mounted config file, or a combination of both. For details about
 openfortivpn configuration run
 
-    docker run --rm jeffre/openfortivpn-haproxy:latest -h
+    docker run --rm innobraingmbh/openfortivpn-socat:latest -h
 
 
 # Examples
@@ -58,7 +58,7 @@ docker run --rm -it \
     --cap-add=NET_ADMIN \
     -p 127.0.0.1:3389:3389 \
     -e PORT_FORWARD="3389:10.0.0.1:3389" \
-    jeffre/openfortivpn-haproxy:latest \
+    innobraingmbh/openfortivpn-socat:latest \
     fortinet.example.com:8443 \
     --username=foo \
     --password=bar \
@@ -76,7 +76,7 @@ docker run --rm -it \
     -e PORT_FORWARD1="1111:10.0.0.1:3389" \
     -p 127.0.0.1:2222:2222 \
     -e PORT_FORWARD2="2222:10.0.0.2:22" \
-    jeffre/openfortivpn-haproxy:latest \
+    innobraingmbh/openfortivpn-socat:latest \
     fortinet.example.com:8443 \
     --username=foo \
     --password=bar \
@@ -103,7 +103,7 @@ docker run --rm -it \
     -p "1111:1111" \
     -e PORT_FORWARD="1111:10.0.0.1:3389" \
     -v "$(pwd)/config:/etc/openfortivpn/config" \
-    jeffre/openfortivpn-haproxy:latest \
+    innobraingmbh/openfortivpn-socat:latest \
     --otp=123456
 ```
 
@@ -117,7 +117,7 @@ docker run --rm -it \
     --privileged \
     -p "1111:1111" \
     -e PORT_FORWARD="3389:10.0.0.1:3389" \
-    jeffre/openfortivpn-haproxy:latest \
+    innobraingmbh/openfortivpn-socat:latest \
     fortinet.example.com:8443
 ```
 


### PR DESCRIPTION
Fix `cd` into a string path
```
    && mkdir -p "/usr/src/openfortivpn" \
    && cd "/usr/src/openfortivpn" \
```

Running the image was causing an error
```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "docker-entrypoint.sh": executable file not found in $PATH: unknown
```